### PR TITLE
docs: Fix a few typos

### DIFF
--- a/docs/caching/index.rst
+++ b/docs/caching/index.rst
@@ -27,7 +27,7 @@ Caching is configured on store creation, via the following API:
     store = http.RESTStore(identifier='my_store', cache=cache)
     manager = store.query(MyModel)
 
-You can use the same :py:class:`Cache` instance accross multiple store if you want, this won't lead to cache collisions.
+You can use the same :py:class:`Cache` instance across multiple store if you want, this won't lead to cache collisions.
 
 
 How does it work?

--- a/docs/overview.rst
+++ b/docs/overview.rst
@@ -13,7 +13,7 @@ a real REST API when it's time.
 .. _TinyDB: http://tinydb.readthedocs.org/en/latest/
 .. _SQLAlchemy: http://docs.sqlalchemy.org/en/rel_1_0/orm/tutorial.html#common-filter-operators
 
-To achieve this, lifter tries to be as agnostic and flexible as possible regarding data sources, while adressing most common use cases.
+To achieve this, lifter tries to be as agnostic and flexible as possible regarding data sources, while addressing most common use cases.
 
 The big picture
 ---------------
@@ -48,7 +48,7 @@ to lifter.
 Adapters
 ********
 
-Because we don't want to deal with raw data such as SQL or JSON Responses, adapters are reponsible for converting
+Because we don't want to deal with raw data such as SQL or JSON Responses, adapters are responsible for converting
 data returned by our refined stores to actual model instances.
 
 Managers

--- a/docs/query.rst
+++ b/docs/query.rst
@@ -380,7 +380,7 @@ You can chain querysets at will using :py:func:`filter` and/or :py:func:`exclude
 
     manager.exclude(User.age == 34).filter(User.is_active == True).filter(User.has_beard == False)
 
-The previous example tranlates to:
+The previous example translates to:
 
 1. In all users, exclude then one where `age` equals 34
 2. Then, from the previous queryset, keep only active users

--- a/lifter/caches.py
+++ b/lifter/caches.py
@@ -36,7 +36,7 @@ class Cache(object):
         :param key: the key to query
         :type key: str
         :param default: the value to return if the key does not exist in cache
-        :param reraise: wether an exception should be thrown if now value is found, defaults to False.
+        :param reraise: whether an exception should be thrown if now value is found, defaults to False.
         :type key: bool
 
         Example usage:


### PR DESCRIPTION
There are small typos in:
- docs/caching/index.rst
- docs/overview.rst
- docs/query.rst
- lifter/caches.py

Fixes:
- Should read `whether` rather than `wether`.
- Should read `translates` rather than `tranlates`.
- Should read `responsible` rather than `reponsible`.
- Should read `addressing` rather than `adressing`.
- Should read `across` rather than `accross`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md